### PR TITLE
Fix the crash not caused by ActivityNotFoundException.

### DIFF
--- a/library/src/main/java/com/drakeet/about/ClickableViewHolder.java
+++ b/library/src/main/java/com/drakeet/about/ClickableViewHolder.java
@@ -1,6 +1,5 @@
 package com.drakeet.about;
 
-import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.view.View;
 import androidx.annotation.Nullable;
@@ -24,7 +23,7 @@ public class ClickableViewHolder extends RecyclerView.ViewHolder {
           intent.setData(parse(url));
           try {
             v.getContext().startActivity(intent);
-          } catch (ActivityNotFoundException e) {
+          } catch (Exception e) {
             e.printStackTrace();
           }
         }

--- a/library/src/main/java/com/drakeet/about/ContributorViewBinder.java
+++ b/library/src/main/java/com/drakeet/about/ContributorViewBinder.java
@@ -1,6 +1,5 @@
 package com.drakeet.about;
 
-import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -71,7 +70,7 @@ public class ContributorViewBinder extends ItemViewBinder<Contributor, Contribut
         intent.setData(parse(data.url));
         try {
           v.getContext().startActivity(intent);
-        } catch (ActivityNotFoundException e) {
+        } catch (Exception e) {
           e.printStackTrace();
         }
       }


### PR DESCRIPTION
This is an example from Wear OS.
```
    java.lang.SecurityException: Permission Denial: starting Intent { act=android.intent.action.VIEW dat=https://github.com/... cmp=com.google.android.wearable.app/com.google.android.clockwork.wcs.remoteintent.UriRedirectActivity } from ProcessRecord{7bca9bc 5244:pkg.name/u0a47} (pid=5244, uid=10047) requires com.google.android.wearable.READ_SETTINGS
        at android.os.Parcel.createException(Parcel.java:1950)
        at android.os.Parcel.readException(Parcel.java:1918)
        at android.os.Parcel.readException(Parcel.java:1868)
        at android.app.IActivityManager$Stub$Proxy.startActivity(IActivityManager.java:3755)
        at java.lang.reflect.Method.invoke(Native Method)
        at leakcanary.ServiceWatcher$install$4$2.invoke(ServiceWatcher.kt:85)
        at java.lang.reflect.Proxy.invoke(Proxy.java:1006)
        at $Proxy2.startActivity(Unknown Source)
        at android.app.Instrumentation.execStartActivity(Instrumentation.java:1669)
        at android.app.Activity.startActivityForResult(Activity.java:4587)
        at androidx.fragment.app.FragmentActivity.startActivityForResult(FragmentActivity.java:676)
        at android.app.Activity.startActivityForResult(Activity.java:4545)
        at androidx.fragment.app.FragmentActivity.startActivityForResult(FragmentActivity.java:663)
        at android.app.Activity.startActivity(Activity.java:4906)
        at android.app.Activity.startActivity(Activity.java:4874)
        at com.drakeet.about.ClickableViewHolder$1.onClick(ClickableViewHolder.java:26)
        at android.view.View.performClick(View.java:6599)
        at android.view.View.performClickInternal(View.java:6576)
        at android.view.View.access$3100(View.java:778)
        at android.view.View$PerformClick.run(View.java:25908)
        at android.os.Handler.handleCallback(Handler.java:873)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6680)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
```